### PR TITLE
Warn about possible memory exhaustion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Versioning <https://semver.org/spec/v2.0.0.html>`__.
 Unreleased
 ----------
 - Fix bug which required geopandas geometry columns to be named "geometry" in `geodataframe_to_cells`.
+- Warn about possible memory exhaustion when encountering a `ArrowIndexError` in
+  `explode_table_include_null` / `geodataframe_to_cells`.
 
 0.19.1 - 2023-10-18
 -------------------

--- a/python/h3ronpy/arrow/util.py
+++ b/python/h3ronpy/arrow/util.py
@@ -7,7 +7,17 @@ def explode_table_include_null(table: pa.Table, column: str) -> pa.Table:
     other_columns = list(table.schema.names)
     other_columns.remove(column)
     indices = pc.list_parent_indices(pc.fill_null(table[column], [None]))
-    result = table.select(other_columns).take(indices)
+    result = table.select(other_columns)
+    try:
+        # may result in a large memory allocation
+        result = result.take(indices)
+    except pa.ArrowIndexError:
+        # See https://github.com/nmandery/h3ronpy/issues/40
+        # Using RuntimeWarning as ResourceWarning is often not displayed to the user.
+        import warnings
+
+        warnings.warn("This ArrowIndexError may be a sign of the process running out of memory.", RuntimeWarning)
+        raise
     result = result.append_column(
         pa.field(column, table.schema.field(column).type.value_type),
         pc.list_flatten(pc.fill_null(table[column], [None])),

--- a/python/h3ronpy/pandas/vector.py
+++ b/python/h3ronpy/pandas/vector.py
@@ -119,6 +119,7 @@ def geodataframe_to_cells(
         containment_mode=containment_mode,
         compact=compact,
         all_intersecting=all_intersecting,
+        flatten=False,
     )
     table = pa.Table.from_pandas(pd.DataFrame(gdf.drop(columns=gdf.geometry.name))).append_column(
         cell_column_name, cells


### PR DESCRIPTION
Warn about possible memory exhaustion when encountering a `ArrowIndexError` in explode_table_include_null/geodataframe_to_cells.

#40