### PR TITLE
inverse width and height during rasterizing

### DIFF
--- a/h3ronpy/python/h3ronpy/arrow/raster.py
+++ b/h3ronpy/python/h3ronpy/arrow/raster.py
@@ -183,6 +183,7 @@ def rasterize_cells(
     del values
 
     values_array = grouped["values"].to_numpy()
+    size = size[::-1]
     rasterized = np.full(size, nodata_value, dtype=values_array.dtype)
 
     for cells, value in zip(grouped["cells_distinct"], grouped["values"]):


### PR DESCRIPTION
numpy needs (height, width), but from_bounds needs (width, height)

generaed rasters are ok according to their transform but images have inversed width and height.