### PR TITLE
declare the version as dynamic

### DIFF
--- a/h3ronpy/pyproject.toml
+++ b/h3ronpy/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 requires-python = ">=3.9"
-
+dynamic = ["version"]
 
 [project.optional-dependencies]
 polars = ["polars>=1"]


### PR DESCRIPTION
`maturin` will take the version from `Cargo.toml`. From the point of view of `pyproject.toml` this means that `version` is dynamic and should be declared as such.