### PR TITLE
Fixes for the updates-202606 migration (follow-up to #90 review)

### DIFF
--- a/h3ronpy/CHANGES.rst
+++ b/h3ronpy/CHANGES.rst
@@ -36,6 +36,7 @@ Unreleased
   ``vertexes_to_wkb_points``, ``directededges_to_wkb_linestrings``) keep
   returning ``large_binary`` arrays (i64 offsets) as in 0.22, and now raise a
   Python exception instead of panicking when the WKB serialization fails.
+- ``ContainmentMode`` is now hashable and can be used as a dict key or in sets.
 
 
 0.22.0 - 2024-11-26

--- a/h3ronpy/CHANGES.rst
+++ b/h3ronpy/CHANGES.rst
@@ -25,13 +25,17 @@ Unreleased
   **>=2.0** for numpy 2 ABI compatibility and for ``shapely.from_wkb``, which
   is used by the raster module.
 - Upgrade the native (Rust) stack: ``h3o`` 0.7 -> 0.10, ``rasterh3`` 0.10 ->
-  0.11, ``geo`` 0.29 -> 0.33, ``arrow`` 53 -> 58, ``geoarrow`` / ``geoarrow-array``
+  0.12, ``geo`` 0.29 -> 0.33, ``arrow`` 53 -> 58, ``geoarrow`` / ``geoarrow-array``
   -> 0.8, ``pyo3`` 0.22 -> 0.28, ``pyo3-arrow`` 0.5.1 -> 0.17, ``ndarray`` 0.16
   -> 0.17, ``numpy`` (Rust) 0.22 -> 0.28.
 - Internal: migrate the ``h3arrow`` crate and the Python bindings to the new
-  geoarrow 0.8 and pyo3 0.28 APIs. There is no change to the Python-facing API;
-  existing user code does not need to be adjusted beyond the dependency bumps
-  above.
+  geoarrow 0.8 and pyo3 0.28 APIs. The signatures of the Python-facing API are
+  unchanged; existing user code does not need to be adjusted beyond the
+  dependency bumps above.
+- The WKB-producing functions (``cells_to_wkb_polygons``, ``cells_to_wkb_points``,
+  ``vertexes_to_wkb_points``, ``directededges_to_wkb_linestrings``) keep
+  returning ``large_binary`` arrays (i64 offsets) as in 0.22, and now raise a
+  Python exception instead of panicking when the WKB serialization fails.
 
 
 0.22.0 - 2024-11-26

--- a/h3ronpy/Cargo.toml
+++ b/h3ronpy/Cargo.toml
@@ -34,6 +34,6 @@ pyo3 = { version = "^0.28", features = [
   "abi3-py312",
 ] }
 pyo3-arrow = { version = "0.17", default-features = false }
-rasterh3 = { version = "0.11", features = ["rayon"] }
+rasterh3 = { version = "0.12", features = ["rayon"] }
 geoarrow-array = { workspace = true }
 rayon = { workspace = true }

--- a/h3ronpy/src/vector.rs
+++ b/h3ronpy/src/vector.rs
@@ -16,7 +16,7 @@ use h3arrow::algorithm::ToCoordinatesOp;
 use h3arrow::array::from_geo::{ToCellIndexArray, ToCellListArray, ToCellsOptions};
 use h3arrow::array::to_geoarrow::{ToWKBLineStrings, ToWKBPoints, ToWKBPolygons};
 use h3arrow::array::{CellIndexArray, ResolutionArray};
-use h3arrow::export::geoarrow::array::{GenericWkbArray, WkbArray, WkbBuilder};
+use h3arrow::export::geoarrow::array::{GenericWkbArray, LargeWkbArray, WkbBuilder};
 use h3arrow::export::h3o::geom::ContainmentMode;
 use h3arrow::export::h3o::Resolution;
 use h3arrow::h3o::geom::SolventBuilder;
@@ -251,7 +251,9 @@ pub(crate) fn cells_to_wkb_polygons(
     let cellindexarray = cellarray.into_inner();
     let use_degrees = !radians;
 
-    let out: WkbArray = py.detach(|| {
+    // LargeWkbArray (i64 offsets) to match the other WKB-producing functions and the
+    // pre-0.23 behavior, and to avoid i32 offset overflow on large outputs.
+    let out: LargeWkbArray = py.detach(|| {
         if link_cells {
             let mut cells = cellindexarray.iter().flatten().collect::<Vec<_>>();
             cells.sort_unstable();

--- a/h3ronpy/src/vector.rs
+++ b/h3ronpy/src/vector.rs
@@ -285,7 +285,7 @@ pub(crate) fn cells_to_wkb_polygons(
         }
     })?;
 
-    let field = Arc::new(out.data_type().to_field("", true));
+    let field = Arc::new(out.data_type().to_field("geometry", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)
 }
 
@@ -300,7 +300,7 @@ pub(crate) fn cells_to_wkb_points(
         .detach(|| cellarray.as_ref().to_wkb_points::<i64>(!radians))
         .into_pyresult()?;
 
-    let field = Arc::new(out.data_type().to_field("", true));
+    let field = Arc::new(out.data_type().to_field("geometry", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)
 }
 
@@ -315,7 +315,7 @@ pub(crate) fn vertexes_to_wkb_points(
         .detach(|| vertexarray.as_ref().to_wkb_points::<i64>(!radians))
         .into_pyresult()?;
 
-    let field = Arc::new(out.data_type().to_field("", true));
+    let field = Arc::new(out.data_type().to_field("geometry", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)
 }
 
@@ -330,7 +330,7 @@ pub(crate) fn directededges_to_wkb_linestrings(
         .detach(|| array.as_ref().to_wkb_linestrings::<i64>(!radians))
         .into_pyresult()?;
 
-    let field = Arc::new(out.data_type().to_field("", true));
+    let field = Arc::new(out.data_type().to_field("geometry", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)
 }
 

--- a/h3ronpy/src/vector.rs
+++ b/h3ronpy/src/vector.rs
@@ -59,8 +59,8 @@ use pyo3_arrow::{PyArray, PyRecordBatch};
 /// * Covers: This mode behaves the same as IntersectsBoundary, but also handles the case where the geometry is
 ///         being covered by a cell without intersecting with its boundaries. In such cases, the covering cell is returned.
 ///
-#[pyclass(name = "ContainmentMode", eq, eq_int, from_py_object)]
-#[derive(Copy, Clone, Eq, PartialEq, Default)]
+#[pyclass(name = "ContainmentMode", eq, eq_int, hash, frozen, from_py_object)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub enum PyContainmentMode {
     #[default]
     ContainsCentroid,

--- a/h3ronpy/src/vector.rs
+++ b/h3ronpy/src/vector.rs
@@ -281,9 +281,7 @@ pub(crate) fn cells_to_wkb_polygons(
                 .into_pyresult()?;
             Ok::<_, PyErr>(builder.finish())
         } else {
-            Ok(cellindexarray
-                .to_wkb_polygons(use_degrees)
-                .expect("wkbarray"))
+            cellindexarray.to_wkb_polygons(use_degrees).into_pyresult()
         }
     })?;
 
@@ -298,12 +296,9 @@ pub(crate) fn cells_to_wkb_points(
     cellarray: PyCellArray,
     radians: bool,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let out = py.detach(|| {
-        cellarray
-            .as_ref()
-            .to_wkb_points::<i64>(!radians)
-            .expect("wkbarray")
-    });
+    let out = py
+        .detach(|| cellarray.as_ref().to_wkb_points::<i64>(!radians))
+        .into_pyresult()?;
 
     let field = Arc::new(out.data_type().to_field("", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)
@@ -316,12 +311,9 @@ pub(crate) fn vertexes_to_wkb_points(
     vertexarray: PyVertexArray,
     radians: bool,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let out = py.detach(|| {
-        vertexarray
-            .as_ref()
-            .to_wkb_points::<i64>(!radians)
-            .expect("wkbarray")
-    });
+    let out = py
+        .detach(|| vertexarray.as_ref().to_wkb_points::<i64>(!radians))
+        .into_pyresult()?;
 
     let field = Arc::new(out.data_type().to_field("", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)
@@ -334,12 +326,9 @@ pub(crate) fn directededges_to_wkb_linestrings(
     array: PyDirectedEdgeArray,
     radians: bool,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let out = py.detach(|| {
-        array
-            .as_ref()
-            .to_wkb_linestrings::<i64>(!radians)
-            .expect("wkbarray")
-    });
+    let out = py
+        .detach(|| array.as_ref().to_wkb_linestrings::<i64>(!radians))
+        .into_pyresult()?;
 
     let field = Arc::new(out.data_type().to_field("", true));
     PyArray::new(out.into_array_ref(), field).into_arro3(py)

--- a/h3ronpy/tests/arrow/test_vector.py
+++ b/h3ronpy/tests/arrow/test_vector.py
@@ -1,7 +1,18 @@
 import h3.api.numpy_int as h3
+import numpy as np
+import pytest
 import shapely
 from arro3.core import Array, DataType, Scalar
-from h3ronpy.vector import ContainmentMode, cells_to_wkb_points, geometry_to_cells
+from h3ronpy import uncompact
+from h3ronpy.vector import (
+    ContainmentMode,
+    cells_to_wkb_points,
+    cells_to_wkb_polygons,
+    directededges_to_wkb_linestrings,
+    geometry_to_cells,
+    vertexes_to_wkb_points,
+    wkb_to_cells,
+)
 from shapely import wkb
 from shapely.geometry import Point
 
@@ -43,3 +54,92 @@ def test_coordinate_values_are_not_equal_issue_58():
         shapely_point = wkb.loads(wkb_point.as_py())
         assert int(lat) == int(shapely_point.y)
         assert int(lon) == int(shapely_point.x)
+
+
+SOME_POLYGON = shapely.Polygon(((10.0, 45.0), (10.0, 46.0), (11.0, 46.0), (11.0, 45.0), (10.0, 45.0)))
+
+
+def test_wkb_outputs_are_large_binary():
+    # regression test: with geoarrow-array 0.8, the `WkbArray` alias uses i32
+    # offsets. All WKB-producing functions must keep returning large_binary
+    # (i64 offsets) as in h3ronpy 0.22.
+    cells = geometry_to_cells(SOME_POLYGON, 5)
+    assert len(cells) > 0
+
+    assert cells_to_wkb_polygons(cells).type == DataType.large_binary()
+    assert cells_to_wkb_polygons(cells, link_cells=True).type == DataType.large_binary()
+    assert cells_to_wkb_points(cells).type == DataType.large_binary()
+
+    some_cell = h3.latlng_to_cell(45.5, 10.2, 5)
+    vertexes = np.array([h3.cell_to_vertex(some_cell, v) for v in range(6)], dtype=np.uint64)
+    assert vertexes_to_wkb_points(vertexes).type == DataType.large_binary()
+
+    edges = np.array(h3.origin_to_directed_edges(some_cell), dtype=np.uint64)
+    assert directededges_to_wkb_linestrings(edges).type == DataType.large_binary()
+
+
+def test_wkb_polygons_field_name_and_extension_metadata():
+    cells = geometry_to_cells(SOME_POLYGON, 5)
+    field = cells_to_wkb_polygons(cells).field
+
+    assert field.name == "geometry"
+    metadata = {
+        (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+        for k, v in field.metadata.items()
+    }
+    assert metadata.get("ARROW:extension:name") == "geoarrow.wkb"
+
+
+def test_wkb_to_cells_flatten_and_compact():
+    wkb_array = Array([shapely.to_wkb(SOME_POLYGON)], type=DataType.binary())
+
+    list_result = wkb_to_cells(wkb_array, 7)
+    flat_result = wkb_to_cells(wkb_array, 7, flatten=True)
+
+    assert flat_result.type == DataType.uint64()
+    cells_from_list = [cell for cells in list_result.to_pylist() for cell in cells]
+    assert sorted(cells_from_list) == sorted(flat_result.to_pylist())
+
+    compact_lists = wkb_to_cells(wkb_array, 7, compact=True)
+    compact_cells = [cell for cells in compact_lists.to_pylist() for cell in cells]
+    assert 0 < len(compact_cells) < len(flat_result)
+    # uncompacting must restore the exact same cell set
+    compact_array = Array(compact_cells, type=DataType.uint64())
+    assert sorted(uncompact(compact_array, 7).to_pylist()) == sorted(flat_result.to_pylist())
+
+
+@pytest.mark.xfail(
+    reason="compact+flatten compacts the already per-geometry-compacted (mixed resolution) "
+    "cells a second time and fails with 'heterogeneous resolution'. Present in 0.22.0 as well.",
+    strict=True,
+)
+def test_wkb_to_cells_compact_and_flatten_combined():
+    wkb_array = Array([shapely.to_wkb(SOME_POLYGON)], type=DataType.binary())
+    wkb_to_cells(wkb_array, 7, compact=True, flatten=True)
+
+
+def test_wkb_to_cells_containment_modes():
+    wkb_array = Array([shapely.to_wkb(SOME_POLYGON)], type=DataType.binary())
+
+    counts = {
+        mode: len(wkb_to_cells(wkb_array, 6, containment_mode=mode, flatten=True))
+        for mode in (
+            ContainmentMode.ContainsBoundary,
+            ContainmentMode.ContainsCentroid,
+            ContainmentMode.IntersectsBoundary,
+            ContainmentMode.Covers,
+        )
+    }
+    assert all(count > 0 for count in counts.values())
+    assert counts[ContainmentMode.ContainsBoundary] <= counts[ContainmentMode.IntersectsBoundary]
+    assert counts[ContainmentMode.ContainsCentroid] <= counts[ContainmentMode.IntersectsBoundary]
+    assert counts[ContainmentMode.IntersectsBoundary] <= counts[ContainmentMode.Covers]
+
+
+def test_wkb_to_cells_null_entries_are_preserved():
+    wkb_array = Array([shapely.to_wkb(SOME_POLYGON), None], type=DataType.binary())
+
+    result = wkb_to_cells(wkb_array, 5).to_pylist()
+    assert len(result) == 2
+    assert len(result[0]) > 0
+    assert result[1] is None


### PR DESCRIPTION
Follow-up to the review comments on #90, as discussed there. All changes are confined to the `h3ronpy` crate (Python bindings) — nothing in `crates/h3arrow` is touched.

## Fixes

- **`cells_to_wkb_polygons` returns `large_binary` again** — geoarrow-array 0.8's `WkbArray` alias is `GenericWkbArray<i32>`; the function now uses `LargeWkbArray` (i64 offsets) like the other `*_to_wkb_*` functions, restoring the 0.22 output dtype and avoiding i32 offset overflow on > 2 GiB payloads.
- **WKB conversion errors raise Python exceptions instead of panicking** — the `ToWKB*` error type is no longer `Infallible`, so the four `.expect("wkbarray")` calls became reachable panic paths. (You mentioned you had started on this one — feel free to drop commit `5d52ea4` in favor of your version.)
- **WKB output field is named `"geometry"` again** (was `""` after the `extension_field()` → `to_field("", true)` change).
- **`rasterh3` 0.11 → 0.12** — picks up the antimeridian and resolution-search fixes from 2026-06-26; compiles without code changes. (Same here — drop `b3626ba` if your version is further along.)
- **`ContainmentMode` is now hashable** (`hash, frozen` on the pyclass) — it was unhashable in 0.22 as well; noticed while writing the containment-mode tests.

## Tests added (`tests/arrow/test_vector.py`)

- all four `*_to_wkb_*` functions return `large_binary`
- the WKB output field is named `geometry` and carries the `ARROW:extension:name = geoarrow.wkb` metadata
- `wkb_to_cells`: flatten/list-array consistency, per-geometry `compact` verified by round-tripping through `uncompact`, containment-mode count ordering, null entries preserved

## Not addressed here (out of scope for the bindings crate)

- **Empty geometries → null entries** (review point 2) lives in `crates/h3arrow/src/array/from_geoarrow.rs` (`try_to_geometry()` returning `None` for empty geometries) — left for you to decide whether to restore the empty-list behavior or document the new semantics.
- **New finding while writing the tests:** `wkb_to_cells(..., compact=True, flatten=True)` fails with `ValueError: heterogeneous resolution` — the flatten path compacts the already per-geometry-compacted (mixed-resolution) cells a second time (`from_geoarrow.rs`, `ToCellIndexArray::to_cellindexarray`). This is **pre-existing** — 0.22.0 from PyPI fails identically — so not a regression from this migration. Documented as an `xfail` test for now.
- The unused `geozero` dependency and the missing `crates/h3arrow/CHANGES.md` entry, for the same reason.

Verified locally on macOS arm64 / Python 3.12: `cargo test --workspace`, `cargo clippy`, `cargo fmt --check`, and the full pytest suite (50 passed, 1 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
